### PR TITLE
feat: add a task to run the Recorder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,8 @@ gatling {
 repositories {
   mavenCentral()
 }
+
+task gatlingRecorder(type: JavaExec) {
+  classpath = sourceSets.gatling.runtimeClasspath
+  mainClass = 'Recorder'
+}


### PR DESCRIPTION
Motivation:
Launching a main in a multi-configuration project for VScode users is a mess

Modifications:
 * add a custom task in build.gradle

Result:
User can now launch their custom recorder from `./gradlew gatlingRecorder` or from the gradle plugin of their IDE