### PR TITLE
fix: removed extra parenthesis

### DIFF
--- a/src/gatling/java/computerdatabase/ComputerDatabaseSimulation.java
+++ b/src/gatling/java/computerdatabase/ComputerDatabaseSimulation.java
@@ -20,7 +20,7 @@ public class ComputerDatabaseSimulation extends Simulation {
     FeederBuilder<String> feeder = csv("search.csv").random();
 
     ChainBuilder search = exec(
-            http("Home").get("/")),
+            http("Home").get("/"),
             pause(1),
             feed(feeder),
             http("Search")


### PR DESCRIPTION
There was an extra parenthesis in ComputerDatabaseSimulation that caused the code to not compile.